### PR TITLE
Use env vars for Supabase client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+Create a `.env` file in the project root with the following keys:
+
+```env
+VITE_SUPABASE_URL=<your Supabase project URL>
+VITE_SUPABASE_KEY=<your Supabase anon key>
+```
+
+These variables are loaded automatically by Vite during `npm run dev` and `npm run build`.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/f3be892c-1c88-496c-9be0-21f69de56308) and click on Share -> Publish.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://ddaltlhlaqblyqedasvn.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRkYWx0bGhsYXFibHlxZWRhc3ZuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1MTc2ODksImV4cCI6MjA2NTA5MzY4OX0.21LNXalJWt01660PficBeMEc-zU9eTfIlJoMVftEW4c";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_KEY: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- load Supabase credentials from `import.meta.env`
- define env vars in `vite-env.d.ts`
- ignore `.env` files
- document required `VITE_SUPABASE_URL` and `VITE_SUPABASE_KEY` variables

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b494a94a0832c9580899a407aab62