### PR TITLE
Add local FastAPI backend and integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,24 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Backend setup
+
+The `backend` folder contains a small FastAPI application that lets you upload
+PDFs and chat using a local language model. To run it locally:
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+By default the server expects a GPT4All model in `models/ggml-gpt4all-j.bin` or
+you can provide a different path using the `LOCAL_MODEL_PATH` environment
+variable. The server exposes two endpoints:
+
+- `POST /upload` – send a PDF file and it will be indexed locally.
+- `POST /chat` – send `{ "message": "..." }` to receive a text reply.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/f3be892c-1c88-496c-9be0-21f69de56308) and click on Share -> Publish.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,76 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.middleware.cors import CORSMiddleware
+from pathlib import Path
+from io import BytesIO
+import uuid, os
+
+from PyPDF2 import PdfReader
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.vectorstores import FAISS
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.chains.question_answering import load_qa_chain
+from langchain.llms import GPT4All
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+VECTOR_PATH = DATA_DIR / "faiss_index"
+EMBEDDINGS = HuggingFaceEmbeddings(model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+vectorstore = None
+
+
+def load_vectorstore():
+    global vectorstore
+    if vectorstore is None:
+        if VECTOR_PATH.exists():
+            vectorstore = FAISS.load_local(str(VECTOR_PATH), EMBEDDINGS, allow_dangerous_deserialization=True)
+        else:
+            vectorstore = None
+    return vectorstore
+
+
+def save_vectorstore(store: FAISS):
+    store.save_local(str(VECTOR_PATH))
+
+
+@app.post("/upload")
+async def upload_pdf(file: UploadFile = File(...)):
+    data = await file.read()
+    reader = PdfReader(BytesIO(data))
+    text = "".join(page.extract_text() or "" for page in reader.pages)
+    file_id = str(uuid.uuid4())
+    (DATA_DIR / f"{file_id}.txt").write_text(text, encoding="utf-8")
+
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+    docs = splitter.split_text(text)
+
+    store = load_vectorstore()
+    if store is None:
+        store = FAISS.from_texts(docs, EMBEDDINGS)
+    else:
+        store.add_texts(docs)
+    save_vectorstore(store)
+    return {"message": "uploaded", "id": file_id}
+
+
+@app.post("/chat")
+async def chat(payload: dict):
+    query = payload.get("message", "")
+    store = load_vectorstore()
+    if store is None:
+        return {"response": "Nenhum documento disponível."}
+    docs = store.similarity_search(query, k=3)
+    model_path = os.environ.get("LOCAL_MODEL_PATH", "models/ggml-gpt4all-j.bin")
+    llm = GPT4All(model=model_path, verbose=False)
+    chain = load_qa_chain(llm, chain_type="stuff")
+    answer = chain.run(input_documents=docs, question=query)
+    return {"response": answer}
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+PyPDF2
+langchain==0.1.6
+faiss-cpu
+gpt4all

--- a/src/services/openaiService.ts
+++ b/src/services/openaiService.ts
@@ -30,9 +30,24 @@ export class OpenAIService {
         return 'Ainda não temos documentos pediátricos na base de conhecimento. Por favor, adicione alguns materiais na seção "Base de Conhecimento" para que eu possa te ajudar melhor. Para questões urgentes, sempre consulte seu pediatra. 💜';
       }
 
-      // If no API key is set, use knowledge-based response
+      // If no API key is set, call the local backend
       if (!this.apiKey) {
-        console.log('No API key set, using knowledge-based response');
+        console.log('No API key set, using local backend');
+        try {
+          const resp = await fetch('http://localhost:8000/chat', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: userMessage })
+          });
+          if (resp.ok) {
+            const data = await resp.json();
+            return data.response as string;
+          }
+          console.error('Local backend error:', resp.status);
+        } catch (err) {
+          console.error('Error calling local backend:', err);
+        }
+
         return this.responseGenerationService.generateKnowledgeBasedResponse(userMessage, knowledgeBase);
       }
 


### PR DESCRIPTION
## Summary
- add `backend/` FastAPI app with `/upload` and `/chat` endpoints
- integrate frontend service to call local backend when OpenAI API key is missing
- document backend setup and endpoints in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_684c55a525dc832cb16c9ad2afd4b51a